### PR TITLE
Make Debug a settable global flag

### DIFF
--- a/FL_Flex.H
+++ b/FL_Flex.H
@@ -17,10 +17,13 @@ struct Fl_Flex : public Fl_Group
 
   void setSize(Fl_Widget* w, int size);
 
+  static void setDebug(bool val) { _debug = val; }
+
 private:
   //const size_t margin = 5;
   const size_t margin = 0;
   const size_t pad = 5;
+  static bool _debug;
 
   int direction;
   std::vector<Fl_Widget*> setsized;

--- a/FL_Flex.cpp
+++ b/FL_Flex.cpp
@@ -2,6 +2,8 @@
 
 #include <FL/Fl.H>
 
+bool Fl_Flex::_debug = false;
+
 Fl_Flex::Fl_Flex(int direction) : Fl_Group(0, 0, 0, 0, 0),
   direction(direction) { debug(); }
 
@@ -14,7 +16,8 @@ Fl_Flex::Fl_Flex(int x, int y, int w, int h, int direction) : Fl_Group(x, y, w, 
 void Fl_Flex::debug()
 {
   // Color the rows and columns to help facilitate development.
-  return;
+  if (!_debug)
+    return;
 
   if(direction == ROW)
   {


### PR DESCRIPTION
I really like the `debug()` function [after I set more reasonable colors! ;-) ].

Allow the developer to activate the `debug()` function by calling `Fl_Flex::setDebug(true);`