### PR TITLE
add default constructor, pad & margin getter & setter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/demo
+/login

--- a/FL_Flex.H
+++ b/FL_Flex.H
@@ -1,31 +1,37 @@
-#include <FL/Fl.H>
 #include <FL/Fl_Group.H>
-
+#include <FL/fl_types.h>
 #include <vector>
 
 struct Fl_Flex : public Fl_Group
 {
-  static const int ROW = 0;
-  static const int COLUMN = 1;
+  static const uchar ROW = 0;
+  static const uchar COLUMN = 1;
 
-  Fl_Flex(int direction);
-  Fl_Flex(int w, int h, int direction);
-  Fl_Flex(int x, int y, int w, int h, int direction);
+  Fl_Flex(uchar direction);
+  Fl_Flex(int w, int h, uchar direction);
+  Fl_Flex(int x, int y, int w, int h, uchar direction);
+  Fl_Flex(int x, int y, int w, int h, const char *label = nullptr);
 
   virtual void end();
   virtual void resize(int x, int y, int w, int h);
 
   void setSize(Fl_Widget* w, int size);
 
+  void margin(int m) { _margin = m; }
+
+  int margin() const { return _margin; }
+
+  void pad(int p) { _pad = p; }
+
+  int pad() const { return _pad; }
+
   static void setDebug(bool val) { _debug = val; }
 
 private:
-  //const size_t margin = 5;
-  const size_t margin = 0;
-  const size_t pad = 5;
+  int _margin = 0;
+  int _pad = 5;
   static bool _debug;
 
-  int direction;
   std::vector<Fl_Widget*> setsized;
 
   void debug();

--- a/FL_Flex.cpp
+++ b/FL_Flex.cpp
@@ -4,14 +4,13 @@
 
 bool Fl_Flex::_debug = false;
 
-Fl_Flex::Fl_Flex(int direction) : Fl_Group(0, 0, 0, 0, 0),
-  direction(direction) { debug(); }
+Fl_Flex::Fl_Flex(uchar direction) : Fl_Group(0, 0, 0, 0, 0) { type(direction); debug(); }
 
-Fl_Flex::Fl_Flex(int w, int h, int direction) : Fl_Group(0, 0, w, h, 0),
-  direction(direction) { debug(); }
+Fl_Flex::Fl_Flex(int w, int h, uchar direction) : Fl_Group(0, 0, w, h, 0) { type(direction); debug(); }
 
-Fl_Flex::Fl_Flex(int x, int y, int w, int h, int direction) : Fl_Group(x, y, w, h, 0),
-  direction(direction) { debug(); }
+Fl_Flex::Fl_Flex(int x, int y, int w, int h, uchar direction) : Fl_Group(x, y, w, h, 0) { type(direction); debug(); }
+
+Fl_Flex::Fl_Flex(int x, int y, int w, int h, const char *label) : Fl_Group(x, y, w, h, label) { type(ROW); debug(); }
 
 void Fl_Flex::debug()
 {
@@ -19,7 +18,7 @@ void Fl_Flex::debug()
   if (!_debug)
     return;
 
-  if(direction == ROW)
+  if(type() == ROW)
   {
     color(fl_rgb_color(200, 0, 0));
     box(FL_BORDER_BOX);
@@ -34,20 +33,20 @@ void Fl_Flex::debug()
 void Fl_Flex::resizeRow(int x, int y, int w, int h)
 {
   int cc = children();
-  int padW = w - margin * 2;
+  int padW = w - _margin * 2;
 
   // Calculate total width minus padding
-  for(size_t i = 1; i < cc; i++)
+  for(int i = 1; i < cc; i++)
   {
     padW -= 5;
   }
 
-  int cx = x + margin;
+  int cx = x + _margin;
   int nrs = 0;
 
   // Precalculate remaining size to resize to
   // Calculate non-resizable width total
-  for(size_t i = 0; i < cc; i++)
+  for(int i = 0; i < cc; i++)
   {
     Fl_Widget *c = child(i);
 
@@ -58,40 +57,40 @@ void Fl_Flex::resizeRow(int x, int y, int w, int h)
   }
 
   // Set children to shared width of remaining
-  for(size_t i = 0; i < cc; i++)
+  for(int i = 0; i < cc; i++)
   {
     Fl_Widget *c = child(i);
 
     if(isSetSize(c))
     {
-      c->resize(cx, y + margin, c->w(), h - margin * 2);
+      c->resize(cx, y + _margin, c->w(), h - _margin * 2);
     }
     else
     {
-      c->resize(cx, y + margin, (padW - nrs) / (cc - (int)setsized.size()), h - margin * 2);
+      c->resize(cx, y + _margin, (padW - nrs) / (cc - (int)setsized.size()), h - _margin * 2);
     }
 
-    cx += c->w() + pad;
+    cx += c->w() + _pad;
   }
 }
 
 void Fl_Flex::resizeCol(int x, int y, int w, int h)
 {
   int cc = children();
-  int padH = h - margin * 2;
+  int padH = h - _margin * 2;
 
   // Calculate total height minus padding
-  for(size_t i = 1; i < cc; i++)
+  for(int i = 1; i < cc; i++)
   {
-    padH -= pad;
+    padH -= _pad;
   }
 
-  int cy = y + margin;
+  int cy = y + _margin;
   int nrs = 0;
 
   // Precalculate remaining size to resize to
   // Calculate non-resizable height total
-  for(size_t i = 0; i < cc; i++)
+  for(int i = 0; i < cc; i++)
   {
     Fl_Widget *c = child(i);
 
@@ -102,13 +101,13 @@ void Fl_Flex::resizeCol(int x, int y, int w, int h)
   }
 
   // Set children to shared width of remaining
-  for(size_t i = 0; i < cc; i++)
+  for(int i = 0; i < cc; i++)
   {
     Fl_Widget *c = child(i);
 
     if(isSetSize(c))
     {
-      c->resize(x + margin, cy, w - margin * 2, c->h());
+      c->resize(x + _margin, cy, w - _margin * 2, c->h());
     }
     else
     {
@@ -116,11 +115,11 @@ void Fl_Flex::resizeCol(int x, int y, int w, int h)
       // This is very handy to allow resizable items to have negative height
       // allowing one on the top and bottom to center contents even if container
       // is too small.
-      c->resize(x + margin, cy, w - margin * 2,
+      c->resize(x + _margin, cy, w - _margin * 2,
         (padH - nrs) / (cc - (int)setsized.size()));
     }
 
-    cy += c->h() + pad;
+    cy += c->h() + _pad;
   }
 }
 
@@ -128,7 +127,7 @@ void Fl_Flex::resize(int x, int y, int w, int h)
 {
   Fl_Widget::resize(x, y, w, h);
 
-  if(direction == COLUMN)
+  if(type() == COLUMN)
   {
     resizeCol(x, y, w, h);
   }

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CXXFLAGS=-I/usr/local/include -I/usr/X11R6/include
-LDFLAGS=-L/usr/local/lib -lfltk
+CXXFLAGS=`fltk-config --cxxflags`
+LDFLAGS=`fltk-config --ldflags`
 
 LSRC= \
   login.cpp \

--- a/demo.cpp
+++ b/demo.cpp
@@ -18,7 +18,7 @@ Fl_Button* createButton(const char* caption)
   return rtn;
 }
 
-Fl_Flex* createMeddle()
+Fl_Flex* createMiddle()
 {
   Fl_Flex* row = new Fl_Flex(Fl_Flex::ROW);
   {
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
         row->resizable(box);
         row->end();
       }
-      col->setSize(createMeddle(), 30);
+      col->setSize(createMiddle(), 30);
       Fl_Button *ub1 = createButton("Something1");
       row = new Fl_Flex(Fl_Flex::ROW);
       {


### PR DESCRIPTION
Hi
Thank you for this repo.
This pull request:
- adds a default constructor à la Fl_Flex(int, int, int, int, const char *). This makes wrapping it via macros easier. Passing 0 for the label doesn't conflict with the (int, int, int, int, int) constructor, where a Row will be created either way.
- the direction is specified via the type() method. This also makes wrapping things easier :)
- adds getters and setters for margin and pad.
- adds a gitignore
- modifies the makefile to use fltk-config, I assume it was for testing anyways.
- fixes some warnings when compiling with -Wall.

Both examples build and run as before.